### PR TITLE
Use stable releases

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -42,7 +42,6 @@ jobs:
       if: matrix.os != 'self-hosted'
       with:
         dotnet-version: '8.0.x'
-        dotnet-quality: 'signed'
         source-url: ${{ env.NUGET_SERVER_URL }}
       env:
         NUGET_AUTH_TOKEN: ${{ secrets.NUGET_AUTH_TOKEN }}


### PR DESCRIPTION
The 'signed' quality is [being removed](https://github.com/dotnet/install-scripts/pull/593) from the install scripts - but your usage is really just a 'stable public release' usage anyway, which is the default.